### PR TITLE
fix: update Kaggle setup based on real competition usage

### DIFF
--- a/SKILLS/kaggle/colab-workflow.md
+++ b/SKILLS/kaggle/colab-workflow.md
@@ -95,16 +95,13 @@ drive.mount('/content/drive')
 
 # Setup Kaggle credentials (one-time)
 import os
-import json
-from getpass import getpass
+from google.colab import files
 
-print("Enter your Kaggle credentials:")
-kaggle_username = input("Kaggle Username: ")
-kaggle_key = getpass("Kaggle API Key: ")
-
+uploaded = files.upload()  # Upload kaggle.json
 os.makedirs('/root/.kaggle', exist_ok=True)
-with open('/root/.kaggle/kaggle.json', 'w') as f:
-    json.dump({"username": kaggle_username, "key": kaggle_key}, f)
+for filename, content in uploaded.items():
+    with open('/root/.kaggle/kaggle.json', 'wb') as f:
+        f.write(content)
 os.chmod('/root/.kaggle/kaggle.json', 0o600)
 
 # Download competition data to Google Drive

--- a/docs/kaggle-user-guide.md
+++ b/docs/kaggle-user-guide.md
@@ -77,26 +77,27 @@ print(f"Created directory structure in: {DRIVE_PATH}")
 
 # ===== セル3: Kaggle API認証 =====
 import os
-import json
-from getpass import getpass
+from google.colab import files
 
-# Kaggle認証情報を入力
-# (https://www.kaggle.com/settings -> API -> Create New Token で取得)
-print("Enter your Kaggle credentials:")
-kaggle_username = input("Kaggle Username: ")
-kaggle_key = getpass("Kaggle API Key: ")
+# kaggle.jsonをアップロード
+print("kaggle.json ファイルをアップロードしてください")
+print("(Settings -> API -> Create New Token でダウンロード)\n")
 
-# kaggle.jsonを作成
+uploaded = files.upload()
+
+# kaggle.jsonを配置
 os.makedirs('/root/.kaggle', exist_ok=True)
-kaggle_json = {"username": kaggle_username, "key": kaggle_key}
-with open('/root/.kaggle/kaggle.json', 'w') as f:
-    json.dump(kaggle_json, f)
+for filename, content in uploaded.items():
+    with open('/root/.kaggle/kaggle.json', 'wb') as f:
+        f.write(content)
 os.chmod('/root/.kaggle/kaggle.json', 0o600)
 
 print("Kaggle API configured successfully!")
 
 # ===== セル4: Kaggle CLIインストール =====
-!pip install -q kaggle
+# 依存関係の問題を回避するためバージョン指定
+!pip uninstall -y kaggle kagglesdk -q 2>/dev/null
+!pip install -q kaggle==1.6.14
 
 # ===== セル5: データセットをGoogle Driveにダウンロード =====
 import os

--- a/kaggle-template/setup_download_data.ipynb
+++ b/kaggle-template/setup_download_data.ipynb
@@ -5,7 +5,7 @@
    "metadata": {
     "id": "header"
    },
-   "source": "# Kaggle Dataset Download to Google Drive\n\nこのノートブックは、Kaggleのデータセットを直接Google Driveにダウンロードします。\n\n## 使い方\n1. Google Colabでこのノートブックを開く\n2. `COMPETITION`変数を自分のコンペ名に変更\n3. セルを順番に実行\n4. Kaggle UsernameとAPI Keyを入力\n5. データがGoogle Driveに保存される\n\n## メリット\n- ローカルディスク容量を節約\n- Colabの高速ネットワークでダウンロード\n- 大容量データセットでも問題なし"
+   "source": "# Kaggle Dataset Download to Google Drive\n\nこのノートブックは、Kaggleのデータセットを直接Google Driveにダウンロードします。\n\n## 使い方\n1. Google Colabでこのノートブックを開く\n2. `COMPETITION`変数を自分のコンペ名に変更\n3. セルを順番に実行\n4. kaggle.jsonファイルをアップロード\n5. データがGoogle Driveに保存される\n\n## 事前準備\n1. https://www.kaggle.com/settings → API → Create New Token\n2. `kaggle.json` ファイルがダウンロードされる\n3. このファイルを安全な場所に保存しておく\n\n## メリット\n- ローカルディスク容量を節約\n- Colabの高速ネットワークでダウンロード\n- 大容量データセットでも問題なし"
   },
   {
    "cell_type": "code",
@@ -83,7 +83,7 @@
     "id": "setup_kaggle_api"
    },
    "outputs": [],
-   "source": "# ========================================\n# 3. Kaggle API認証設定\n# ========================================\n\nimport os\nimport json\nfrom getpass import getpass\n\n# Kaggle認証情報を入力\n# (https://www.kaggle.com/settings -> API -> Create New Token で取得)\nprint(\"Enter your Kaggle credentials:\")\nprint(\"(Get from: https://www.kaggle.com/settings -> API -> Create New Token)\\n\")\n\nkaggle_username = input(\"Kaggle Username: \")\nkaggle_key = getpass(\"Kaggle API Key: \")\n\n# kaggle.jsonを作成\nos.makedirs('/root/.kaggle', exist_ok=True)\n\nkaggle_json = {\n    \"username\": kaggle_username,\n    \"key\": kaggle_key\n}\n\nwith open('/root/.kaggle/kaggle.json', 'w') as f:\n    json.dump(kaggle_json, f)\n\nos.chmod('/root/.kaggle/kaggle.json', 0o600)\n\nprint(\"\\n✓ Kaggle API configured successfully!\")"
+   "source": "# ========================================\n# 3. Kaggle API認証設定\n# ========================================\n\nimport os\nfrom google.colab import files\n\n# kaggle.jsonをアップロード\n# (https://www.kaggle.com/settings -> API -> Create New Token で取得)\nprint(\"kaggle.json ファイルをアップロードしてください\")\nprint(\"(Settings -> API -> Create New Token でダウンロード)\\n\")\n\nuploaded = files.upload()\n\n# kaggle.jsonを配置\nos.makedirs('/root/.kaggle', exist_ok=True)\n\n# アップロードされたファイルを保存\nfor filename, content in uploaded.items():\n    with open('/root/.kaggle/kaggle.json', 'wb') as f:\n        f.write(content)\n    print(f\"\\n✓ {filename} を読み込みました\")\n\nos.chmod('/root/.kaggle/kaggle.json', 0o600)\n\nprint(\"✓ Kaggle API configured successfully!\")"
   },
   {
    "cell_type": "code",
@@ -92,18 +92,7 @@
     "id": "install_kaggle"
    },
    "outputs": [],
-   "source": [
-    "# ========================================\n",
-    "# 4. Kaggle CLIをインストール\n",
-    "# ========================================\n",
-    "\n",
-    "!pip install -q kaggle\n",
-    "\n",
-    "# インストール確認\n",
-    "!kaggle --version\n",
-    "\n",
-    "print(\"\\n✓ Kaggle CLI installed successfully!\")"
-   ]
+   "source": "# ========================================\n# 4. Kaggle CLIをインストール\n# ========================================\n\n# 依存関係の問題を回避するためバージョン指定\n!pip uninstall -y kaggle kagglesdk -q 2>/dev/null\n!pip install -q kaggle==1.6.14\n\n# インストール確認\n!kaggle --version\n\nprint(\"\\n✓ Kaggle CLI installed successfully!\")"
   },
   {
    "cell_type": "code",
@@ -223,32 +212,7 @@
    "metadata": {
     "id": "footer"
    },
-   "source": [
-    "---\n",
-    "\n",
-    "## トラブルシューティング\n",
-    "\n",
-    "### エラー: \"403 - Forbidden\"\n",
-    "- コンペの規約に同意していない可能性があります\n",
-    "- Kaggleのコンペページで \"Join Competition\" をクリックして規約に同意してください\n",
-    "\n",
-    "### エラー: \"404 - Not found\"\n",
-    "- コンペ名が間違っている可能性があります\n",
-    "- `COMPETITION`変数を正しいコンペ名に設定してください\n",
-    "- コンペ名はKaggle URLから取得できます: `https://www.kaggle.com/competitions/{competition-name}`\n",
-    "\n",
-    "### ダウンロードが遅い\n",
-    "- Colabのネットワークは通常高速ですが、大容量データセット（10GB以上）の場合は時間がかかります\n",
-    "- セルの実行が完了するまで待ちましょう\n",
-    "\n",
-    "### Google Driveの容量不足\n",
-    "- Google Driveの容量を確認してください（無料版は15GB）\n",
-    "- 不要なファイルを削除するか、Google Oneで容量をアップグレードしてください\n",
-    "\n",
-    "---\n",
-    "\n",
-    "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-   ]
+   "source": "---\n\n## トラブルシューティング\n\n### エラー: \"401 - Unauthorized\"\n- APIトークンが無効または期限切れの可能性があります\n- https://www.kaggle.com/settings → API → Create New Token で新しいトークンを生成してください\n- **重要**: 新しいトークン形式（KGAT_で始まる）は `kaggle>=1.6.14` が必要です\n- ランタイムを再起動してから再度実行してください\n\n### エラー: \"403 - Forbidden\"\n- コンペの規約に同意していない可能性があります\n- Kaggleのコンペページで \"Join Competition\" または \"Late Submission\" をクリックして規約に同意してください\n\n### エラー: \"404 - Not found\"\n- コンペ名が間違っている可能性があります\n- `COMPETITION`変数を正しいコンペ名に設定してください\n- コンペ名はKaggle URLから取得できます: `https://www.kaggle.com/competitions/{competition-name}`\n\n### エラー: \"ImportError: cannot import name ... from 'kagglesdk'\"\n- kaggleパッケージの依存関係問題です\n- ランタイムを再起動し、`pip install kaggle==1.6.14` を最初に実行してください\n\n### ダウンロードが遅い\n- Colabのネットワークは通常高速ですが、大容量データセット（10GB以上）の場合は時間がかかります\n- セルの実行が完了するまで待ちましょう\n\n### Google Driveの容量不足\n- Google Driveの容量を確認してください（無料版は15GB）\n- 不要なファイルを削除するか、Google Oneで容量をアップグレードしてください\n\n---\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Revert to JSON file upload method (more reliable in practice)
- Pin kaggle==1.6.14 to fix dependency issues with new token format
- Add uninstall step to avoid kagglesdk conflicts
- Add troubleshooting for 401 and ImportError issues

## Test plan
- [x] Tested with actual Kaggle competition (stanford-rna-3d-folding-2)
- [ ] Verify setup_download_data.ipynb works in Google Colab

🤖 Generated with [Claude Code](https://claude.com/claude-code)