### PR TITLE
chore: add .gitignore for security and cleanliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,98 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv/
+venv/
+ENV/
+
+# Jupyter
+.ipynb_checkpoints/
+*.ipynb_checkpoints
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.coverage
+htmlcov/
+.tox/
+.nox/
+.pytest_cache/
+.mypy_cache/
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build outputs
+*.log
+*.tmp
+*.temp
+
+# Credentials and secrets
+.env
+.env.*
+*.pem
+*.key
+kaggle.json
+credentials.json
+secrets.json
+*_credentials.json
+*_secrets.json
+
+# Kaggle data (large files)
+data/
+input/
+output/
+submissions/
+*.csv
+*.parquet
+*.feather
+*.h5
+*.hdf5
+*.pkl
+*.pickle
+
+# Downloaded notebooks (from Kaggle API)
+data/kaggle_notebooks/
+
+# Model files (large)
+*.pt
+*.pth
+*.onnx
+*.bin
+models/
+
+# Claude Code local settings
+.claude/settings.local.json
+
+# Archives
+docs/archive/


### PR DESCRIPTION
## Summary
- 機密情報の誤コミット防止のため.gitignoreを追加
- Python、Node.js、Kaggle関連ファイルを除外対象に設定

## 除外対象
- 認証情報: `kaggle.json`, `.env`, `*.pem`
- Python: `.venv/`, `__pycache__/`
- Kaggleデータ: `data/`, `*.csv`, `*.parquet`
- IDE/OS: `.idea/`, `.vscode/`, `.DS_Store`
- Claude Code: `.claude/settings.local.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)