### PR TITLE
feat: port Kaggle discussion scraper from AIMO3

### DIFF
--- a/.claude/commands/kaggle-update.md
+++ b/.claude/commands/kaggle-update.md
@@ -8,6 +8,7 @@
 - `/kaggle-update leaderboard` - リーダーボードのみ
 - `/kaggle-update notebooks` - ノートブック一覧のみ
 - `/kaggle-update submissions` - 自分の提出履歴のみ
+- `/kaggle-update discussions` - ディスカッション取得（増分更新）
 - `/kaggle-update $ARGUMENTS` - カスタム引数で実行
 
 ## Competition Target
@@ -112,9 +113,43 @@ uv run kaggle kernels pull <kernel-ref> -p data/kaggle_notebooks/<notebook-name>
 uv run kaggle competitions submissions <competition-name>
 ```
 
-### 4. 手動確認リンク (API非対応)
-- Discussions: https://www.kaggle.com/competitions/<competition-name>/discussion
-- Announcements: https://www.kaggle.com/competitions/<competition-name>/discussion?sort=top
+### 4. ディスカッション
+Playwright ベースのスクレイパーで全ディスカッション + コメントを取得:
+```bash
+# 増分更新（推奨: 新規・更新トピックのみ取得、~1-2分）
+uv run python scripts/fetch_discussions.py --competition <competition-name> --update --delay 10.0
+
+# 初回フル取得（全トピック、~50-60分）
+uv run python scripts/fetch_discussions.py --competition <competition-name> --delay 10.0
+
+# トピック一覧のみ（高速）
+uv run python scripts/fetch_discussions.py --competition <competition-name> --topics-only
+
+# 中断再開
+uv run python scripts/fetch_discussions.py --competition <competition-name> --resume --delay 10.0
+```
+
+**出力先**: `docs/discussions/`
+```
+docs/discussions/
+├── topic_list.json          # トピック一覧メタデータ
+├── discussions_full.json    # 全トピック詳細 + コメント
+├── INDEX.md                 # Markdown インデックス
+└── markdown/                # トピック別 .md ファイル
+```
+
+**注意事項**:
+- 初回は `--delay 10.0` を推奨（Kaggle レートリミット対策）
+- `--update` は前回の `discussions_full.json` の `fetchedAt` を基準に差分検出
+- Playwright + Chromium が必要: `uv sync --extra kaggle && uv run playwright install chromium`
+- スクリプト詳細・内部 API の仕組みは `.claude/skills/kaggle/kaggle-scraping.md` を参照
+
+**取得後のアクション**:
+1. `docs/discussions/INDEX.md` を読んで新しいトピックを確認
+2. 重要な知見は `COMPETITION_TRACKER.md` に反映
+3. 採用候補のテクニックは `SKILL.md` の Next Steps に追加
+
+### 5. 手動確認リンク
 - Overview: https://www.kaggle.com/competitions/<competition-name>/overview
 
 ## Notebook Storage

--- a/.claude/skills/kaggle/SKILL.md
+++ b/.claude/skills/kaggle/SKILL.md
@@ -26,6 +26,7 @@ uv run kaggle competitions submit -c competition-name -f submission.csv -m "Mess
 
 ### Setup and Tools
 - [kaggle-api-setup.md](kaggle-api-setup.md) - Kaggle API installation and authentication guide
+- [kaggle-scraping.md](kaggle-scraping.md) - Playwright スクレイピング + discussion 一括取得スクリプト
 - [colab-workflow.md](colab-workflow.md) - Google Colab + Claude Code development workflow
 - [claude-friendly-outputs.md](claude-friendly-outputs.md) - Creating outputs Claude can review locally
 - [data-analysis-workflow.md](data-analysis-workflow.md) - Complete data analysis workflow with Claude + Colab

--- a/.claude/skills/kaggle/kaggle-scraping.md
+++ b/.claude/skills/kaggle/kaggle-scraping.md
@@ -1,0 +1,157 @@
+# Kaggle ページスクレイピング（Playwright）
+
+KaggleはJavaScript SPAのため、`WebFetch` ではページ内容を取得できない。
+`playwright` を使ってブラウザレンダリング後のテキストを取得する。
+
+## 前提
+
+```bash
+uv sync --extra kaggle          # playwright が含まれる
+uv run playwright install chromium
+```
+
+## 基本パターン
+
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    url = "https://www.kaggle.com/competitions/COMP_NAME/overview"
+    page.goto(url, wait_until="networkidle", timeout=30000)
+    page.wait_for_timeout(5000)  # JS レンダリング待ち
+
+    content = page.inner_text("body")
+    # content は長いので分割して読む
+    print(content[:10000])
+    # print(content[10000:20000])  # 続き
+
+    browser.close()
+```
+
+## 取得対象別 URL
+
+| タブ | URL パス |
+|------|---------|
+| Overview | `/competitions/COMP_NAME/overview` |
+| Rules | `/competitions/COMP_NAME/rules` |
+| Data | `/competitions/COMP_NAME/data` |
+| Discussion | `/competitions/COMP_NAME/discussion` |
+| Leaderboard | `/competitions/COMP_NAME/leaderboard` |
+| Notebook | `/code/USER/NOTEBOOK_NAME` |
+
+## 注意事項
+
+- **認証不要**: 公開ページはログインなしで取得可能
+- **出力が長い**: `body` のテキストは数万文字になるため、`content[start:end]` でスライスして読む
+- **タイムアウト**: `wait_until="networkidle"` + `wait_for_timeout(5000)` でほぼ確実にレンダリング完了
+- **Kaggle API で取れるもの**: ファイル一覧、リーダーボード、ノートブックダウンロードは API の方が効率的
+- **Playwright が必要な場面**: Overview、Rules、Evaluation の本文テキスト、Discussion の内容
+
+---
+
+## Discussion 一括取得スクリプト
+
+`kaggle-template/scripts/fetch_discussions.py` で competition の全 discussion（トピック一覧 + 各トピックのコメント）を取得できる。
+
+Kaggleコンペ用プロジェクトではテンプレートをコピーした時点でスクリプトも使える:
+
+```bash
+cp -r kaggle-template/ my-competition/
+cd my-competition/
+uv sync --extra kaggle
+uv run playwright install chromium
+```
+
+### 仕組み
+
+Kaggle は Discussion の公開 API を提供していない。内部 API を以下の方法で利用:
+
+1. **トピック一覧**: Playwright で cookie 取得 → `requests` で内部 API を直接呼び出し（高速）
+2. **トピック詳細**: Playwright でページを個別訪問し、`GetForumTopicById` レスポンスをインターセプト
+
+内部 API エンドポイント（`/api/i/discussions.DiscussionsService/`）:
+
+| エンドポイント | 用途 | 認証 |
+|---|---|---|
+| `GetForum` | フォーラム ID 取得 | 不要 |
+| `GetTopicListByForumId` | トピック一覧（ページネーション） | 不要 |
+| `GetForumTopicById` | トピック詳細 + コメント | **ブラウザコンテキスト必須** |
+
+`GetForumTopicById` は `requests` からの直接呼び出しでは 404 を返す（Kaggle がブラウザコンテキストを検証）。
+そのため Playwright でのページ訪問が必要。
+
+### 使い方
+
+```bash
+# 全 discussion 取得（初回）
+uv run python scripts/fetch_discussions.py --competition <slug> --delay 10.0
+
+# 差分更新（前回以降の新規・更新トピックのみ取得）
+uv run python scripts/fetch_discussions.py --competition <slug> --update --delay 10.0
+
+# コメント未取得分だけ再取得（中断からの復帰）
+uv run python scripts/fetch_discussions.py --competition <slug> --resume --delay 10.0
+
+# トピック一覧だけ取得（高速、数十秒）
+uv run python scripts/fetch_discussions.py --competition <slug> --topics-only
+
+# 件数制限（テスト用）
+uv run python scripts/fetch_discussions.py --competition <slug> --limit 5 --delay 5.0
+```
+
+`--competition` を省略したい場合は、スクリプト先頭の `DEFAULT_COMPETITION` を書き換える。
+
+### 出力先
+
+`docs/discussions/` に出力される:
+
+```
+docs/discussions/
+├── topic_list.json          # 全トピックのメタデータ（タイトル、著者、投票数等）
+├── discussions_full.json    # 全トピック詳細 + コメント（JSON）
+├── INDEX.md                 # 一覧インデックス
+└── markdown/                # 各トピックの個別 Markdown ファイル
+    ├── 687017_Nemotron-Cascade-....md
+    ├── 680552_Apply here for ....md
+    └── ...
+```
+
+### Rate Limit 対策
+
+Kaggle は動的 rate limit を適用する。以下の知見に基づいて設計:
+
+| パラメータ | 推奨値 | 説明 |
+|---|---|---|
+| `--delay` | **10.0** | ページ間の待機秒数。10秒で 298 件取得時に rate limit 回避を確認 |
+| API throttle | 0.5秒/リクエスト（固定） | 1 ページロードで ~17 件の内部 API が発火。各リクエストに 0.5 秒の遅延を挿入 |
+| トピック一覧 | 1.0秒/ページ（固定） | 20件/ページ × 15ページ程度 |
+
+- **1 ページあたりの負荷**: HTML 1 + JS/CSS ~4 + 内部 API ~17 = **約 22 リクエスト**
+- `--delay 10.0` での所要時間: 約 **50-60 分**（~170 件未取得時）
+- `--delay 5.0` でも動く可能性はあるが、rate limit リスクが上がる
+- rate limit に引っかかった場合: **数十分〜数時間待つ必要がある**（UI でもページが見れなくなる）
+
+### `--update` の動作（差分更新）
+
+`discussions_full.json` の `fetchedAt` タイムスタンプを基準に差分を検出:
+
+- **新規トピック**: `topic_list` にあるが `discussions_full.json` にないもの
+- **更新トピック**: `lastCommentPostDate` が `fetchedAt` 以降のもの（新しいコメントが付いた）
+
+変更のあったトピックだけ Playwright で再取得し、既存データにマージする。
+新規2件 + 更新3件 なら約1分で完了（フル取得の50分と比較して大幅に高速）。
+
+### `--resume` の動作
+
+- `discussions_full.json` からコメント付きトピックをキャッシュとして読み込む
+- コメント 0 件のトピックは再取得対象（前回 rate limit で取得失敗した可能性）
+- トピック一覧の取得に失敗した場合、`topic_list.json` からフォールバック
+
+### 外部リクエストのブロック
+
+スクリプトは Playwright の route 機能で外部サービス（Google Analytics, fonts 等）をブロックし、
+Kaggle への不要なリクエストを削減している。
+**Kaggle 内部 API はブロックしてはいけない**（SPA の初期化に必要で、ブロックすると `GetForumTopicById` が発火しない）。

--- a/kaggle-template/scripts/fetch_discussions.py
+++ b/kaggle-template/scripts/fetch_discussions.py
@@ -1,0 +1,489 @@
+"""
+Kaggle Competition Discussion Scraper
+
+Hybrid approach:
+- Topic list: requests + Kaggle internal API (fast)
+- Topic details: Playwright page visits with response interception
+  (required because Kaggle validates browser context for this endpoint)
+
+Usage:
+    uv run python scripts/fetch_discussions.py                    # Full fetch
+    uv run python scripts/fetch_discussions.py --topics-only      # List only
+    uv run python scripts/fetch_discussions.py --resume --delay 1  # Resume incomplete
+    uv run python scripts/fetch_discussions.py --limit 10          # First 10 details
+
+Requirements:
+    uv pip install playwright requests
+    uv run playwright install chromium
+"""
+
+import asyncio
+import argparse
+import json
+import time
+from pathlib import Path
+
+import requests
+from playwright.async_api import async_playwright
+
+
+DEFAULT_COMPETITION = "your-competition-slug"  # override via --competition / -c
+DEFAULT_OUTPUT_DIR = "docs/discussions"
+API_BASE = "https://www.kaggle.com/api/i/discussions.DiscussionsService"
+
+
+# ---------------------------------------------------------------------------
+# Step 1 & 2: Session cookies + topic list via requests (fast)
+# ---------------------------------------------------------------------------
+
+async def get_session_cookies_and_forum_id(competition_slug: str) -> tuple[dict, int | None]:
+    """Use Playwright once to get cookies and forum ID."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        ctx = await browser.new_context()
+        page = await ctx.new_page()
+
+        forum_id = None
+
+        async def capture(response):
+            nonlocal forum_id
+            if "GetForum" in response.url and "discussions" in response.url.lower():
+                try:
+                    body = await response.json()
+                    forum_id = body.get("forum", {}).get("id")
+                except Exception:
+                    pass
+
+        page.on("response", capture)
+        await page.goto(
+            f"https://www.kaggle.com/competitions/{competition_slug}/discussion",
+            wait_until="networkidle", timeout=30000,
+        )
+        await page.wait_for_timeout(2000)
+
+        cookies = {c["name"]: c["value"] for c in await ctx.cookies()}
+        await browser.close()
+        return cookies, forum_id
+
+
+def fetch_all_topics(cookies: dict, forum_id: int) -> list[dict]:
+    """Fetch all topics via requests + internal API."""
+    session = requests.Session()
+    for k, v in cookies.items():
+        session.cookies.set(k, v)
+    headers = {
+        "Content-Type": "application/json",
+        "X-XSRF-TOKEN": cookies.get("XSRF-TOKEN", ""),
+    }
+
+    all_topics = []
+    page_num = 1
+
+    while True:
+        payload = {
+            "forumId": forum_id,
+            "page": page_num,
+            "category": "TOPIC_LIST_CATEGORY_ALL",
+            "group": "TOPIC_LIST_GROUP_ALL",
+            "customGroupingIds": [],
+            "author": "TOPIC_LIST_AUTHOR_UNSPECIFIED",
+            "myActivity": "TOPIC_LIST_MY_ACTIVITY_UNSPECIFIED",
+            "recency": "TOPIC_LIST_RECENCY_UNSPECIFIED",
+            "filterCategoryIds": [],
+            "searchQuery": "",
+            "sortBy": "TOPIC_LIST_SORT_BY_UNSPECIFIED",
+        }
+
+        resp = session.post(f"{API_BASE}/GetTopicListByForumId", json=payload, headers=headers)
+        if resp.status_code != 200:
+            print(f"  Error: {resp.status_code} {resp.text[:300]}")
+            break
+
+        data = resp.json()
+        topics = data.get("topics", [])
+        total = data.get("count", 0)
+
+        if not topics:
+            break
+
+        all_topics.extend(topics)
+        print(f"  Page {page_num}: {len(all_topics)}/{total} topics")
+
+        if len(all_topics) >= total:
+            break
+
+        page_num += 1
+        time.sleep(1.0)
+
+    return all_topics
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Topic details via Playwright (browser context required)
+# ---------------------------------------------------------------------------
+
+async def fetch_topic_details_batch(
+    competition_slug: str,
+    topic_ids: list[int],
+    delay: float = 1.0,
+    batch_size: int = 1,
+) -> dict[str, dict]:
+    """Fetch topic details by visiting each page in Playwright."""
+    results = {}
+
+    # Block external third-party requests and throttle Kaggle internal APIs.
+    # The SPA fires ~17 API calls per page load; throttling spreads them out.
+    BLOCK_EXTERNAL = [
+        "google-analytics.com",
+        "googletagmanager.com",
+        "accounts.google.com",
+        "fonts.googleapis.com",
+        "fonts.gstatic.com",
+        "apis.google.com",
+        "firebaseio.com",
+        "typekit.net",
+        ".png",
+        ".jpg",
+        ".svg",
+        ".woff",
+    ]
+    # Delay per internal API call (seconds). With ~17 calls/page,
+    # 0.5s = ~8.5s of throttled API time per page.
+    API_THROTTLE = 0.5
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        ctx = await browser.new_context()
+
+        block_external = BLOCK_EXTERNAL
+        api_throttle = API_THROTTLE
+
+        async def route_handler(route):
+            url = route.request.url
+            if any(pat in url for pat in block_external):
+                await route.abort()
+            elif "/api/i/" in url:
+                await asyncio.sleep(api_throttle)
+                await route.continue_()
+            else:
+                await route.continue_()
+
+        for i, tid in enumerate(topic_ids):
+            page = await ctx.new_page()
+            captured = {}
+
+            await page.route("**/*", route_handler)
+
+            async def make_handler(_captured=captured):
+                async def handler(response):
+                    if "GetForumTopicById" in response.url:
+                        try:
+                            _captured["data"] = await response.json()
+                        except Exception:
+                            pass
+                return handler
+
+            page.on("response", await make_handler())
+
+            url = f"https://www.kaggle.com/competitions/{competition_slug}/discussion/{tid}"
+            try:
+                await page.goto(url, wait_until="networkidle", timeout=60000)
+                await page.wait_for_timeout(1500)
+            except Exception as e:
+                print(f"    Warning on {tid}: {e}")
+
+            ft = captured.get("data", {}).get("forumTopic", {})
+            n_comments = len(ft.get("comments", []))
+            title = ft.get("title", "")[:60]
+            print(f"  [{i+1}/{len(topic_ids)}] {title} ({n_comments} comments)")
+
+            results[str(tid)] = ft
+            await page.close()
+
+            # Periodic save every 50 topics
+            if (i + 1) % 50 == 0:
+                print(f"    [checkpoint: {len(results)} topics saved]")
+
+            await asyncio.sleep(delay)
+
+        await browser.close()
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Markdown output
+# ---------------------------------------------------------------------------
+
+def flatten_comments(comments: list[dict], depth: int = 0) -> list[dict]:
+    """Flatten nested comment replies into a flat list with depth info."""
+    result = []
+    for c in comments:
+        c_flat = {**c, "_depth": depth}
+        c_flat.pop("replies", None)
+        result.append(c_flat)
+        for reply in c.get("replies", []):
+            result.extend(flatten_comments([reply], depth + 1))
+    return result
+
+
+def format_discussion_markdown(topic: dict, meta: dict | None = None) -> str:
+    """Convert a topic with comments to readable markdown.
+
+    Args:
+        topic: Topic detail from GetForumTopicById (comments, author, etc.)
+        meta: Topic metadata from topic list (title, votes, postDate, etc.)
+    """
+    meta = meta or {}
+    lines = []
+    title = meta.get("title") or topic.get("title", "Untitled")
+    author = topic.get("authorUserDisplayName") or meta.get("authorUser", {}).get("displayName", "Unknown")
+    date = meta.get("postDate") or topic.get("dateCreated", "")
+    votes = meta.get("votes", 0) or topic.get("voteCount", 0)
+    topic_id = meta.get("id") or topic.get("id", "")
+    topic_url = meta.get("topicUrl", "")
+
+    lines.append(f"# {title}")
+    lines.append("")
+    lines.append(f"**Author:** {author} | **Date:** {date} | **Votes:** {votes} | **ID:** {topic_id}")
+    if topic_url:
+        lines.append(f"**URL:** https://www.kaggle.com{topic_url}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # The first comment in the detail is often the topic body
+    raw_comments = topic.get("comments", [])
+    all_comments = flatten_comments(raw_comments)
+
+    if all_comments:
+        lines.append(f"## Discussion ({len(all_comments)} messages)")
+        lines.append("")
+        for c in all_comments:
+            c_author = c.get("authorDisplayName", "Unknown")
+            c_date = c.get("postDate", "")
+            c_content = c.get("content") or c.get("rawMarkdown", "(no content)")
+            c_votes = c.get("voteCount", 0)
+            indent = ">" * c.get("_depth", 0)
+            prefix = f"{indent} " if indent else ""
+
+            lines.append(f"### {prefix}{c_author} ({c_date}) [votes: {c_votes}]")
+            lines.append("")
+            if indent:
+                lines.append(f"{prefix}{c_content}")
+            else:
+                lines.append(c_content)
+            lines.append("")
+    else:
+        lines.append("(no comments)")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def save_outputs(
+    all_details: dict, topic_meta: dict[str, dict],
+    output_dir: Path, competition: str,
+):
+    details_path = output_dir / "discussions_full.json"
+    with open(details_path, "w") as f:
+        json.dump(
+            {
+                "competition": competition,
+                "fetchedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "topics": all_details,
+            },
+            f, indent=2, ensure_ascii=False,
+        )
+    print(f"  Saved JSON to {details_path}")
+
+    md_dir = output_dir / "markdown"
+    md_dir.mkdir(exist_ok=True)
+
+    index_lines = [
+        f"# {competition} Discussions\n",
+        f"Fetched: {time.strftime('%Y-%m-%d %H:%M UTC')}\n",
+        f"Total: {len(all_details)} topics\n\n",
+    ]
+
+    for tid, detail in all_details.items():
+        meta = topic_meta.get(str(tid), {})
+        title = meta.get("title") or detail.get("title", "Untitled")
+        all_comments = flatten_comments(detail.get("comments", []))
+        safe = "".join(c if c.isalnum() or c in " -_" else "" for c in title)[:80].strip()
+        if not safe:
+            safe = "Untitled"
+        md_path = md_dir / f"{tid}_{safe}.md"
+        with open(md_path, "w") as f:
+            f.write(format_discussion_markdown(detail, meta))
+        index_lines.append(f"- [{title}](markdown/{md_path.name}) ({len(all_comments)} messages)")
+
+    with open(output_dir / "INDEX.md", "w") as f:
+        f.write("\n".join(index_lines))
+    print(f"  Saved markdown to {md_dir}/")
+
+
+# ---------------------------------------------------------------------------
+# Incremental update
+# ---------------------------------------------------------------------------
+
+def _find_updated_topics(
+    all_topics: list[dict], existing: dict[str, dict], prev_fetched_at: str,
+) -> list[dict]:
+    """Find topics that are new or have been updated since prev_fetched_at.
+
+    A topic needs re-fetching if:
+    1. It doesn't exist in the previous data (new topic), OR
+    2. Its lastCommentPostDate is after prev_fetched_at (has new comments)
+    """
+    new_topics = []
+    updated_topics = []
+
+    for topic in all_topics:
+        tid = str(topic["id"])
+        if tid not in existing:
+            new_topics.append(topic)
+            continue
+
+        last_comment = topic.get("lastCommentPostDate", "")
+        if last_comment and last_comment > prev_fetched_at:
+            updated_topics.append(topic)
+
+    if new_topics:
+        print(f"  New topics: {len(new_topics)}")
+    if updated_topics:
+        print(f"  Updated topics (new comments): {len(updated_topics)}")
+    if not new_topics and not updated_topics:
+        print("  No changes since last fetch.")
+
+    return new_topics + updated_topics
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch Kaggle competition discussions")
+    parser.add_argument("--competition", "-c", default=DEFAULT_COMPETITION)
+    parser.add_argument("--output", "-o", default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--topics-only", action="store_true")
+    parser.add_argument("--limit", type=int, default=0, help="Limit topics (0 = all)")
+    parser.add_argument("--resume", action="store_true", help="Skip already-fetched topics")
+    parser.add_argument("--update", action="store_true",
+                        help="Incremental update: only fetch new/updated topics since last run")
+    parser.add_argument("--delay", type=float, default=1.0, help="Delay between page visits (s)")
+    args = parser.parse_args()
+
+    if args.competition == "your-competition-slug":
+        parser.error(
+            "competition slug is not set. Pass --competition <slug> "
+            "or edit DEFAULT_COMPETITION at the top of this script."
+        )
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    topic_list_path = output_dir / "topic_list.json"
+    details_path = output_dir / "discussions_full.json"
+
+    print(f"Fetching discussions for: {args.competition}")
+    start = time.time()
+
+    # Step 1: Cookies + forum ID
+    print("\n[Step 1] Getting session via Playwright...")
+    cookies, forum_id = asyncio.run(get_session_cookies_and_forum_id(args.competition))
+    print(f"  forum_id={forum_id}")
+
+    if not forum_id:
+        print("  ERROR: Could not get forum ID")
+        return
+
+    # Step 2: Topic list via requests
+    print("\n[Step 2] Fetching topic list...")
+    all_topics = fetch_all_topics(cookies, forum_id)
+    print(f"  Total: {len(all_topics)} topics")
+
+    # Fallback to previous data if fetch failed
+    if not all_topics and args.resume:
+        if topic_list_path.exists():
+            with open(topic_list_path) as f:
+                all_topics = json.load(f).get("topics", [])
+        if not all_topics and details_path.exists():
+            with open(details_path) as f:
+                for tid, d in json.load(f).get("topics", {}).items():
+                    all_topics.append({"id": int(tid), "title": d.get("title", "")})
+        if all_topics:
+            print(f"  Loaded {len(all_topics)} from previous run")
+
+    if all_topics:
+        with open(topic_list_path, "w") as f:
+            json.dump({
+                "competition": args.competition, "forumId": forum_id,
+                "totalTopics": len(all_topics),
+                "fetchedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "topics": all_topics,
+            }, f, indent=2, ensure_ascii=False)
+
+    if args.topics_only:
+        return
+
+    # Load existing details
+    existing = {}
+    prev_fetched_at = None
+    if (args.resume or args.update) and details_path.exists():
+        with open(details_path) as f:
+            prev_data = json.load(f)
+        existing = prev_data.get("topics", {})
+        prev_fetched_at = prev_data.get("fetchedAt")
+        if args.resume:
+            # Keep only topics that have comments (re-fetch empty ones)
+            existing = {
+                k: v for k, v in existing.items()
+                if len(v.get("comments", [])) > 0
+            }
+            print(f"  Resuming: {len(existing)} topics with comments cached")
+        elif args.update:
+            print(f"  Previous fetch: {prev_fetched_at} ({len(existing)} topics)")
+
+    # Determine which topics need fetching
+    targets = all_topics
+    if args.limit > 0:
+        targets = all_topics[:args.limit]
+
+    if args.update and prev_fetched_at:
+        need_fetch = _find_updated_topics(targets, existing, prev_fetched_at)
+    else:
+        need_fetch = [t for t in targets if str(t["id"]) not in existing]
+
+    print(f"\n[Step 3] Fetching {len(need_fetch)} topic details via Playwright (delay={args.delay}s)...")
+
+    if need_fetch:
+        new_details = asyncio.run(
+            fetch_topic_details_batch(
+                args.competition,
+                [t["id"] for t in need_fetch],
+                delay=args.delay,
+            )
+        )
+        # Merge
+        all_details = {**existing, **new_details}
+    else:
+        all_details = existing
+        print("  All topics already cached.")
+
+    # Build topic metadata lookup from topic list
+    topic_meta = {str(t["id"]): t for t in all_topics}
+
+    # Save
+    save_outputs(all_details, topic_meta, output_dir, args.competition)
+
+    elapsed = time.time() - start
+    total_comments = sum(
+        len(flatten_comments(d.get("comments", []))) for d in all_details.values()
+    )
+    print(f"\nDone in {elapsed:.0f}s — {len(all_details)} topics, {total_comments} comments")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/kaggle-template/scripts/fetch_discussions.py
+++ b/kaggle-template/scripts/fetch_discussions.py
@@ -7,15 +7,17 @@ Hybrid approach:
   (required because Kaggle validates browser context for this endpoint)
 
 Usage:
-    uv run python scripts/fetch_discussions.py                    # Full fetch
-    uv run python scripts/fetch_discussions.py --topics-only      # List only
-    uv run python scripts/fetch_discussions.py --resume --delay 1  # Resume incomplete
-    uv run python scripts/fetch_discussions.py --limit 10          # First 10 details
+    uv run python scripts/fetch_discussions.py --competition <slug>                    # Full fetch
+    uv run python scripts/fetch_discussions.py --competition <slug> --topics-only      # List only
+    uv run python scripts/fetch_discussions.py --competition <slug> --resume --delay 1 # Resume incomplete
+    uv run python scripts/fetch_discussions.py --competition <slug> --limit 10         # First 10 details
 
 Requirements:
-    uv pip install playwright requests
+    uv sync --extra kaggle
     uv run playwright install chromium
 """
+
+from __future__ import annotations
 
 import asyncio
 import argparse
@@ -126,7 +128,6 @@ async def fetch_topic_details_batch(
     competition_slug: str,
     topic_ids: list[int],
     delay: float = 1.0,
-    batch_size: int = 1,
 ) -> dict[str, dict]:
     """Fetch topic details by visiting each page in Playwright."""
     results = {}
@@ -200,9 +201,9 @@ async def fetch_topic_details_batch(
             results[str(tid)] = ft
             await page.close()
 
-            # Periodic save every 50 topics
+            # Progress marker (note: results are persisted only at the end)
             if (i + 1) % 50 == 0:
-                print(f"    [checkpoint: {len(results)} topics saved]")
+                print(f"    [progress: {len(results)} topics fetched]")
 
             await asyncio.sleep(delay)
 
@@ -286,7 +287,7 @@ def save_outputs(
     output_dir: Path, competition: str,
 ):
     details_path = output_dir / "discussions_full.json"
-    with open(details_path, "w") as f:
+    with open(details_path, "w", encoding="utf-8") as f:
         json.dump(
             {
                 "competition": competition,
@@ -314,11 +315,11 @@ def save_outputs(
         if not safe:
             safe = "Untitled"
         md_path = md_dir / f"{tid}_{safe}.md"
-        with open(md_path, "w") as f:
+        with open(md_path, "w", encoding="utf-8") as f:
             f.write(format_discussion_markdown(detail, meta))
         index_lines.append(f"- [{title}](markdown/{md_path.name}) ({len(all_comments)} messages)")
 
-    with open(output_dir / "INDEX.md", "w") as f:
+    with open(output_dir / "INDEX.md", "w", encoding="utf-8") as f:
         f.write("\n".join(index_lines))
     print(f"  Saved markdown to {md_dir}/")
 
@@ -406,17 +407,17 @@ def main():
     # Fallback to previous data if fetch failed
     if not all_topics and args.resume:
         if topic_list_path.exists():
-            with open(topic_list_path) as f:
+            with open(topic_list_path, encoding="utf-8") as f:
                 all_topics = json.load(f).get("topics", [])
         if not all_topics and details_path.exists():
-            with open(details_path) as f:
+            with open(details_path, encoding="utf-8") as f:
                 for tid, d in json.load(f).get("topics", {}).items():
                     all_topics.append({"id": int(tid), "title": d.get("title", "")})
         if all_topics:
             print(f"  Loaded {len(all_topics)} from previous run")
 
     if all_topics:
-        with open(topic_list_path, "w") as f:
+        with open(topic_list_path, "w", encoding="utf-8") as f:
             json.dump({
                 "competition": args.competition, "forumId": forum_id,
                 "totalTopics": len(all_topics),
@@ -431,7 +432,7 @@ def main():
     existing = {}
     prev_fetched_at = None
     if (args.resume or args.update) and details_path.exists():
-        with open(details_path) as f:
+        with open(details_path, encoding="utf-8") as f:
             prev_data = json.load(f)
         existing = prev_data.get("topics", {})
         prev_fetched_at = prev_data.get("fetchedAt")

--- a/uv.lock
+++ b/uv.lock
@@ -781,15 +781,7 @@ version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/f5/e4f5a35864293a8605bf6e9366d406ee11565b91a22f38f8b8665096c718/cmake-4.2.1.tar.gz", hash = "sha256:a07a790ca65946667c0fb286549e8e0b5a850e2f8170ae60d3418573011ca218", size = 37060, upload-time = "2025-12-21T11:23:47.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/83/7b6ff5b0f64f764db5e87ac4c320dfc34a783f38601b2f0c1dfe0ffcbab1/cmake-4.2.1-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c5742041f8e641d977928207e2697e9cc3242d0d01f7cb8671f63ad45dcc447b", size = 29838727, upload-time = "2025-12-21T11:22:53.799Z" },
-    { url = "https://files.pythonhosted.org/packages/64/48/81fa5fa5bf19b7be74ba83ea3eddc20210995b066e3acb2329e8f821bd4e/cmake-4.2.1-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ae0f51d2b8dd00a7ac1578c19364140358596e449d2ac1b978af3f0b35737d01", size = 27768477, upload-time = "2025-12-21T11:22:57.608Z" },
     { url = "https://files.pythonhosted.org/packages/28/19/b54ff2e03946beeef785e6407d965a9493d26c50dd1aa09ffc7b53fbf9a5/cmake-4.2.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6333a2b16e1d55373419b9c1572a155b315bfb9d834fbdbba0f7d3428437c785", size = 28919242, upload-time = "2025-12-21T11:23:01.177Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/82/b001aac0162af8524067a94005e61e23426103b9283c2525df62f0b403ea/cmake-4.2.1-py3-none-manylinux_2_31_armv7l.whl", hash = "sha256:4d7a62c462cc81a6f7a5e4db7b298b4e66d851010418c8cdc5a9de0a8701f60f", size = 26109769, upload-time = "2025-12-21T11:23:04.627Z" },
-    { url = "https://files.pythonhosted.org/packages/28/62/c4e8810012175ca76bb4be565955b73354a8693a4a9e983206be7cd9144e/cmake-4.2.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3455391ffce8a860bbbd22b83c2188f13806100a21f28b8ab2c6a785def25616", size = 26217175, upload-time = "2025-12-21T11:23:07.952Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c2/c37989f2366d700f934b6c557dfd74e078352f7535b63d35920f1b0e49fd/cmake-4.2.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:52db8740e81d10c8d103899c87e0100e6aab969295ab99ce51eb11de4c36c9ce", size = 34564791, upload-time = "2025-12-21T11:23:15.177Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/a7/91b4504199f587c11b612f7bedcb8943d6f2da679d6e627e2de962a95011/cmake-4.2.1-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:3d8d7632bb27cf1d0ac78098f2f7dfb7019927f35fb5a8c1508b17524af70000", size = 39610499, upload-time = "2025-12-21T11:23:23Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/4e/6aabf0172544c6b021ef0192f3f9bd8bb0f2877ad9ae223e653982aebd62/cmake-4.2.1-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:3e89d391096fdbdaab82e28b7e1fa964a873c0ba8d77c3542260c7d115aaac1f", size = 34796816, upload-time = "2025-12-21T11:23:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/f1/a2ae37cc5ff4338165a322e2dc70ddd0713a2989dee1ccf1af4ddf4917da/cmake-4.2.1-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:e758ae635c75aaf0258e2c46fe95a3821f01011d5dbe29b7f045976b88ce3ca8", size = 36826277, upload-time = "2025-12-21T11:23:30.702Z" },
     { url = "https://files.pythonhosted.org/packages/fe/5b/ffa3551f85fd26dddc0e5d2e5dff0cda50fce57aaf2b237f2d5210d74203/cmake-4.2.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fecc03edef6257b2bc8784f7880e84fe8a0b0fb54c952528c61ce14a4d693e16", size = 37806089, upload-time = "2025-12-21T11:23:34.464Z" },
 ]
 
@@ -3817,10 +3809,12 @@ kaggle = [
     { name = "kaggle", version = "1.8.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mlflow", version = "3.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mlflow", version = "3.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "playwright" },
     { name = "polars", version = "1.36.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "polars", version = "1.37.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytorch-tabnet" },
     { name = "shap" },
+    { name = "tqdm" },
     { name = "wandb" },
 ]
 test = [
@@ -3850,6 +3844,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "optuna", specifier = ">=3.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "playwright", marker = "extra == 'kaggle'", specifier = ">=1.40.0" },
     { name = "plotly", specifier = ">=5.17.0" },
     { name = "polars", marker = "extra == 'kaggle'", specifier = ">=0.20.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -3860,6 +3855,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "seaborn", specifier = ">=0.12.0" },
     { name = "shap", marker = "extra == 'kaggle'", specifier = ">=0.47.0" },
+    { name = "tqdm", marker = "extra == 'kaggle'", specifier = ">=4.66.0" },
     { name = "wandb", marker = "extra == 'kaggle'", specifier = ">=0.16.0" },
     { name = "xgboost", specifier = ">=2.0.0" },
 ]
@@ -4861,6 +4857,26 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", version = "3.2.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "greenlet", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "plotly"
 version = "6.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5370,6 +5386,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

AIMO3 リポジトリで使われていた Playwright ベースの Kaggle discussion 一括取得機能を、汎用テンプレートに取り込みました。コンペ slug はプレースホルダ化してあるため、任意の Kaggle コンペで `--competition <slug>` を渡すだけで動作します。

- **`kaggle-template/scripts/fetch_discussions.py`** — Hybrid scraper。トピック一覧は `requests` + Kaggle 内部 API（高速）、トピック詳細は Playwright ページ訪問で `GetForumTopicById` をインターセプト。`--update`（差分更新）・`--resume`（中断再開）・`--topics-only` をサポート
- **`.claude/skills/kaggle/kaggle-scraping.md`** — Playwright スクレイピング全般の how-to と、`fetch_discussions.py` の仕組み（内部 API エンドポイント）・rate limit 知見（`--delay 10.0` 推奨）・差分更新ロジックを解説
- **`.claude/commands/kaggle-update.md`** — `/kaggle-update discussions` サブコマンドと Section 4 を追加。従来「Discussions は API 非対応」と手動リンクを表示していた箇所を、スクレイパー呼び出しに置換
- **`.claude/skills/kaggle/SKILL.md`** — Resources index から新スキルにリンク
- **`uv.lock`** — pyproject に宣言済みだが lock に反映されていなかった `playwright` / `tqdm` を取り込み（副作用的修正）

## Test plan

- [x] `uv run --extra kaggle python kaggle-template/scripts/fetch_discussions.py --help` が正常終了
- [x] 未設定の placeholder slug のまま実行すると `argparse.error` で停止
- [ ] 実コンペ（例: `titanic`）で `--topics-only` 実行し、`docs/discussions/topic_list.json` が生成されることを確認
- [ ] `--update` 2 回目実行で差分 0 件になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)