### PR TITLE
refactor: cleanup template — placeholders, dedupe CLAUDE.md, drop src/mytools

### DIFF
--- a/.claude/skills/kaggle/claude-friendly-outputs.md
+++ b/.claude/skills/kaggle/claude-friendly-outputs.md
@@ -100,7 +100,7 @@ class ExperimentReporter:
         return report_path
 
 # Usage in Colab
-reporter = ExperimentReporter('/content/drive/MyDrive/kaggle/cafa-6/outputs/reports')
+reporter = ExperimentReporter('/content/drive/MyDrive/kaggle/my-competition/outputs/reports')
 report = reporter.create_report(
     experiment_name="baseline_v1",
     metrics={"val_f1": 0.875, "val_auc": 0.923, "train_time_sec": 145.2},
@@ -210,7 +210,7 @@ class PlotSaver:
         return filepath
 
 # Usage
-plotter = PlotSaver('/content/drive/MyDrive/kaggle/cafa-6/outputs/plots')
+plotter = PlotSaver('/content/drive/MyDrive/kaggle/my-competition/outputs/plots')
 
 # Feature importance plot
 fig, ax = plt.subplots(figsize=(10, 8))
@@ -246,7 +246,7 @@ def log_experiment(log_file, experiment_data):
 
 # Usage
 log_experiment(
-    '/content/drive/MyDrive/kaggle/cafa-6/outputs/experiments.jsonl',
+    '/content/drive/MyDrive/kaggle/my-competition/outputs/experiments.jsonl',
     {
         'experiment_id': 'baseline_v1',
         'config': {'model': 'lgbm', 'n_estimators': 1000},
@@ -283,7 +283,7 @@ class TeeLogger:
         self.log.flush()
 
 # Usage in Colab
-sys.stdout = TeeLogger('/content/drive/MyDrive/kaggle/cafa-6/outputs/logs/training.log')
+sys.stdout = TeeLogger('/content/drive/MyDrive/kaggle/my-competition/outputs/logs/training.log')
 
 print("Starting training...")
 model.fit(X_train, y_train)
@@ -357,7 +357,7 @@ def create_data_summary(df, output_path):
 # Usage
 create_data_summary(
     train_df,
-    '/content/drive/MyDrive/kaggle/cafa-6/outputs/reports/data_summary.md'
+    '/content/drive/MyDrive/kaggle/my-competition/outputs/reports/data_summary.md'
 )
 ```
 
@@ -443,7 +443,7 @@ class ReportWatcher(FileSystemEventHandler):
 observer = Observer()
 observer.schedule(
     ReportWatcher(),
-    path='~/GoogleDrive/kaggle/cafa-6/outputs/reports',
+    path='~/GoogleDrive/kaggle/my-competition/outputs/reports',
     recursive=False
 )
 observer.start()
@@ -493,7 +493,7 @@ from pathlib import Path
 from datetime import datetime
 
 # Setup paths
-DRIVE_BASE = Path('/content/drive/MyDrive/kaggle/cafa-6')
+DRIVE_BASE = Path('/content/drive/MyDrive/kaggle/my-competition')
 OUTPUT_DIR = DRIVE_BASE / 'outputs'
 REPORTS_DIR = OUTPUT_DIR / 'reports'
 PLOTS_DIR = OUTPUT_DIR / 'plots'
@@ -533,7 +533,7 @@ print("📁 Open in Claude Code to review results")
 
 ```bash
 # After Google Drive syncs
-cd ~/GoogleDrive/kaggle/cafa-6/outputs/reports
+cd ~/GoogleDrive/kaggle/my-competition/outputs/reports
 
 # Claude can read the latest report
 cat experiment_baseline_v1_20240115.md

--- a/.claude/skills/kaggle/colab-workflow.md
+++ b/.claude/skills/kaggle/colab-workflow.md
@@ -49,8 +49,8 @@ Complete guide for Kaggle competition development using Claude Code locally with
 
 ```bash
 # Create competition directory
-mkdir -p kaggle-competitions/cafa-6
-cd kaggle-competitions/cafa-6
+mkdir -p kaggle-competitions/my-competition
+cd kaggle-competitions/my-competition
 
 # Initialize Python environment
 uv init
@@ -58,7 +58,7 @@ uv sync --extra kaggle
 
 # Initialize git repository
 git init
-git remote add origin https://github.com/your-username/cafa-6.git
+git remote add origin https://github.com/your-username/my-competition.git
 ```
 
 ### 2. Google Drive Structure
@@ -68,7 +68,7 @@ Create the following structure in Google Drive:
 ```
 My Drive/
 └── kaggle/
-    └── cafa-6/
+    └── my-competition/
         ├── data/
         │   ├── raw/              # Original competition data
         │   ├── processed/        # Preprocessed datasets
@@ -105,15 +105,15 @@ for filename, content in uploaded.items():
 os.chmod('/root/.kaggle/kaggle.json', 0o600)
 
 # Download competition data to Google Drive
-!kaggle competitions download -c cafa-6-protein-function-prediction \
-    -p /content/drive/MyDrive/kaggle/cafa-6/data/raw/
+!kaggle competitions download -c your-competition-slug \
+    -p /content/drive/MyDrive/kaggle/my-competition/data/raw/
 ```
 
 **Option B: Upload from local**
 
 ```bash
 # Use Google Drive desktop app or web interface
-# Upload data files to Drive/kaggle/cafa-6/data/raw/
+# Upload data files to Drive/kaggle/my-competition/data/raw/
 ```
 
 ## Development Workflow
@@ -128,7 +128,7 @@ Create modular Python code in your local repository:
 Data loading utilities for Colab environment.
 """
 
-def load_train_data(drive_path='/content/drive/MyDrive/kaggle/cafa-6/data/raw'):
+def load_train_data(drive_path='/content/drive/MyDrive/kaggle/my-competition/data/raw'):
     """Load training data from Google Drive."""
     import pandas as pd
     from pathlib import Path
@@ -137,7 +137,7 @@ def load_train_data(drive_path='/content/drive/MyDrive/kaggle/cafa-6/data/raw'):
     train_df = pd.read_csv(data_path / 'train.csv')
     return train_df
 
-def load_test_data(drive_path='/content/drive/MyDrive/kaggle/cafa-6/data/raw'):
+def load_test_data(drive_path='/content/drive/MyDrive/kaggle/my-competition/data/raw'):
     """Load test data from Google Drive."""
     import pandas as pd
     from pathlib import Path
@@ -203,13 +203,13 @@ from google.colab import drive
 drive.mount('/content/drive')
 
 # Define paths
-DRIVE_BASE = '/content/drive/MyDrive/kaggle/cafa-6'
+DRIVE_BASE = '/content/drive/MyDrive/kaggle/my-competition'
 DATA_PATH = f'{DRIVE_BASE}/data/raw'
 MODEL_PATH = f'{DRIVE_BASE}/models'
 OUTPUT_PATH = f'{DRIVE_BASE}/outputs'
 
 # 2. Clone your GitHub repository
-!git clone https://github.com/your-username/cafa-6.git /content/repo
+!git clone https://github.com/your-username/my-competition.git /content/repo
 %cd /content/repo
 
 # 3. Install dependencies
@@ -478,7 +478,7 @@ from google.colab import files
 uploaded = files.upload()  # Select your .py file
 
 # Or copy from Drive
-!cp /content/drive/MyDrive/kaggle/cafa-6/src/*.py /content/repo/src/
+!cp /content/drive/MyDrive/kaggle/my-competition/src/*.py /content/repo/src/
 ```
 
 ### 3. Download Results to Local
@@ -524,11 +524,11 @@ if 'COLAB_TPU_ADDR' in os.environ:
 **Solutions:**
 ```python
 # Copy data to Colab local storage first
-!cp -r /content/drive/MyDrive/kaggle/cafa-6/data/raw /content/data
+!cp -r /content/drive/MyDrive/kaggle/my-competition/data/raw /content/data
 DATA_PATH = '/content/data'
 
 # Process locally, save results back to Drive
-# model.save('/content/drive/MyDrive/kaggle/cafa-6/models/model.pkl')
+# model.save('/content/drive/MyDrive/kaggle/my-competition/models/model.pkl')
 ```
 
 ### Issue: Module import errors after code update
@@ -573,7 +573,7 @@ gc.collect()
 # === Local Setup (Claude Code) ===
 
 # 1. Create repository
-mkdir cafa-6 && cd cafa-6
+mkdir my-competition && cd my-competition
 git init
 
 # 2. Setup Python environment
@@ -589,7 +589,7 @@ git add .
 git commit -m "chore: initial project structure"
 
 # 5. Push to GitHub
-git remote add origin https://github.com/username/cafa-6.git
+git remote add origin https://github.com/username/my-competition.git
 git push -u origin main
 ```
 
@@ -601,10 +601,10 @@ from google.colab import drive
 drive.mount('/content/drive')
 
 import os
-os.makedirs('/content/drive/MyDrive/kaggle/cafa-6/data/raw', exist_ok=True)
-os.makedirs('/content/drive/MyDrive/kaggle/cafa-6/models', exist_ok=True)
-os.makedirs('/content/drive/MyDrive/kaggle/cafa-6/submissions', exist_ok=True)
-os.makedirs('/content/drive/MyDrive/kaggle/cafa-6/outputs', exist_ok=True)
+os.makedirs('/content/drive/MyDrive/kaggle/my-competition/data/raw', exist_ok=True)
+os.makedirs('/content/drive/MyDrive/kaggle/my-competition/models', exist_ok=True)
+os.makedirs('/content/drive/MyDrive/kaggle/my-competition/submissions', exist_ok=True)
+os.makedirs('/content/drive/MyDrive/kaggle/my-competition/outputs', exist_ok=True)
 
 print("Google Drive structure created!")
 ```

--- a/.claude/skills/kaggle/kaggle-api-setup.md
+++ b/.claude/skills/kaggle/kaggle-api-setup.md
@@ -147,11 +147,11 @@ uv run kaggle models instances versions download username/model-name/framework/v
 
 ```bash
 # Get competition files
-uv run kaggle competitions download -c cafa-6-protein-function-prediction
+uv run kaggle competitions download -c your-competition-slug
 
 # Download top notebooks
 uv run kaggle kernels list \
-  --competition cafa-6-protein-function-prediction \
+  --competition your-competition-slug \
   --sort-by voteCount \
   --page-size 5
 
@@ -258,7 +258,7 @@ export KAGGLE_VERIFY_SSL=false
 #!/bin/bash
 # setup-competition.sh
 
-COMP_NAME="cafa-6-protein-function-prediction"
+COMP_NAME="your-competition-slug"
 
 # Create directory structure
 mkdir -p competition/$COMP_NAME/{data,notebooks,submissions}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,20 +103,8 @@ uv run jupyter lab              # Start JupyterLab
 ```
 
 ### Kaggle API Commands
-```bash
-# Setup: Place kaggle.json in ~/.kaggle/ (get from kaggle.com/account)
-uv run kaggle competitions list              # List competitions
-uv run kaggle competitions download -c NAME  # Download competition data
-uv run kaggle competitions submit -c NAME -f submission.csv -m "Message"
 
-uv run kaggle kernels list --competition NAME --sort-by voteCount  # Top notebooks
-uv run kaggle kernels pull user/notebook-name -p ./notebooks/      # Download notebook
-
-uv run kaggle datasets list --search "query"  # Search datasets
-uv run kaggle datasets download user/dataset  # Download dataset
-```
-
-See `.claude/skills/kaggle/kaggle-api-setup.md` for detailed setup instructions.
+Kaggle CLI のセットアップと全コマンドリファレンスは `.claude/skills/kaggle/kaggle-api-setup.md` を参照。
 
 ## Code Style
 
@@ -159,27 +147,9 @@ SKILL.mdでの参照例:
 
 ## Agent Teams (Experimental)
 
-マルチエージェント協調ワークフロー機能。複数のClaude Codeセッションがチームとして連携する。
+マルチエージェント協調ワークフロー機能。`.claude/settings.json` で `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` を設定済み。
 
-### セットアップ
-`.claude/settings.json` で `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` を設定済み。
-
-### 定義済みエージェント（`.claude/agents/`）
-| エージェント | 用途 |
-|---|---|
-| `team-lead` | チームオーケストレーター（PDCA対応） |
-| `frontend-dev` | フロントエンド開発 |
-| `backend-dev` | バックエンド開発 |
-| `qa-tester` | テスト・QA |
-| `code-reviewer` | コードレビュー |
-| `tech-innovation-advisor` | 技術戦略アドバイス |
-| `experiment-engineer` | 実験実行・パラメータ変更・結果検証 |
-| `data-analyst` | データ分析・仮説生成 |
-| `notebook-developer` | Kaggle/Colabノートブック開発 |
-
-### 使い方
-- チーム起動: `TeamCreate` → `TaskCreate` → `Task`（teammate spawn）
-- 詳細: `.claude/skills/teams/` を参照
+エージェント一覧・チームパターン・ライフサイクル・ファイル所有権ルールは `.claude/skills/teams/SKILL.md` を参照。
 
 ## File Structure
 


### PR DESCRIPTION
## Summary

テンプレート向けに `CLAUDE.md` と `.claude/skills/kaggle/` の冗長箇所を整理、かつ `src/mytools/` デモコードを削除してテンプレートを依存コンテナ化。

### A. ハードコードされたコンペ名の placeholder 化
`cafa-6` / `cafa-6-protein-function-prediction`（過去コンペ名）が kaggle skill 配下の 3 ファイル計 28+ 箇所に残っていた。以下に置換:

- `cafa-6-protein-function-prediction` → `your-competition-slug`
- `cafa-6` → `my-competition`

対象: `claude-friendly-outputs.md`, `colab-workflow.md`, `kaggle-api-setup.md`

### B. CLAUDE.md Kaggle CLI セクションの圧縮
L105-119 の CLI コマンド一覧は `.claude/skills/kaggle/kaggle-api-setup.md` に完全に含まれていたため、pointer 1 行に圧縮。

### C. CLAUDE.md Agent Teams セクションの圧縮
L160-182 のエージェント一覧・ライフサイクル記述は `.claude/skills/teams/SKILL.md` により詳細版があるため、簡潔な pointer に置換。

### D. `src/mytools/` デモコードの削除とテンプレートの依存コンテナ化
テンプレートに同梱されていた sklearn チュートリアルコード（`DataProcessor`, `SimpleMLModel`）と対応するテスト群を削除。`test_kaggle_reporting.py` に至っては存在しない `kaggle_utils.reporting` モジュールを import しており最初から壊れていた。

- `src/`, `tests/` を完全削除（11 ファイル, -488 行）
- `pyproject.toml` を hatchling ビルド構成から `[tool.uv] package = false`（依存コンテナ）に変更。将来パッケージ化したい場合の復帰手順はコメントで記載
- `uv.lock` では `source = { editable = "." }` → `{ virtual = "." }` に変化
- CLAUDE.md Initial Setup の src/tests 関連のトリガー・削除対象・リネームステップを除去

### 対応見送り（別 PR 候補）

- `colab-workflow.md`（619 行）と `data-analysis-workflow.md`（647 行）の Colab/Drive セットアップ重複

## Test plan

- [x] `grep -rn "cafa" .claude/` が空
- [x] `grep -rn "mytools" CLAUDE.md` が残存のトリガー条件（`name = "mytools-python"`）のみ
- [x] `uv sync` が `[tool.uv] package = false` で正常完了
- [x] `uv run --extra kaggle python kaggle-template/scripts/fetch_discussions.py --help` が引き続き動作
- [ ] テンプレート clone → 新規 Kaggle/Python プロジェクトで引き続き動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)